### PR TITLE
Update mellotrainer.json

### DIFF
--- a/mellotrainer/nui/mellotrainer.json
+++ b/mellotrainer/nui/mellotrainer.json
@@ -2820,13 +2820,13 @@
         }
       },
       {
-        "menuName": "Hraphite",
+        "menuName": "Graphite",
         "data": {
           "action": 1
         }
       },
       {
-        "menuName": "Anhracite Black",
+        "menuName": "Anthracite Black",
         "data": {
           "action": 11
         }
@@ -7710,7 +7710,7 @@
       {
         "menuName": "MTL Dune",
         "data": {
-          "action": "DUNE"
+          "action": "RALLYTRUCK"
         }
       },
       {


### PR DESCRIPTION
Fixed a couple of typos and corrected the model name for the MTL Dune. The model "DUNE" belongs to the small dune buggy.